### PR TITLE
Feature/1077: Removed CrossIcon from preview form 

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,3 +43,7 @@ body {
   outline: 2px solid #3b82f6;
   outline-offset: 2px;
 }
+
+.MuiIconButton-root svg[data-testid="CloseIcon"] {
+  display: none;
+}


### PR DESCRIPTION
<img width="1431" height="514" alt="Screenshot 2025-12-16 at 5 43 03 PM" src="https://github.com/user-attachments/assets/3c4ffab5-5482-4f5a-a28a-60d96dbb98cb" />

Removed CrossIcon from preview form .