### PR TITLE
Added optional description field to form builder

### DIFF
--- a/apps/form-builder-basic-demo/src/controls/CustomFileUploadControl.jsx
+++ b/apps/form-builder-basic-demo/src/controls/CustomFileUploadControl.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { Box, Typography, Alert } from '@mui/material';
+import { Box, Typography, Alert, FormHelperText } from '@mui/material';
 import { IconUpload, IconFile } from '@tabler/icons-react';
 import { and, isControl, optionIs, rankWith } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 const CustomFileUploadControl = (props) => {
   const { t } = useTranslation();
 
-  const { data, handleChange, path, errors, uischema } = props;
+  const { data, handleChange, path, errors, uischema, schema, label } = props;
 
   const [isDragOver, setIsDragOver] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
@@ -110,6 +110,11 @@ const CustomFileUploadControl = (props) => {
 
   return (
     <Box sx={{ mb: 2 }}>
+      {label && (
+        <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+          {label}
+        </Typography>
+      )}
       <Box
         sx={{
           border: 2,
@@ -183,6 +188,9 @@ const CustomFileUploadControl = (props) => {
         <Alert severity="error" sx={{ mt: 1 }}>
           {localError || jsonFormsError || 'Invalid file'}
         </Alert>
+      )}
+      {schema?.description && (
+        <FormHelperText sx={{ mt: 1, mx: 0 }}>{schema.description}</FormHelperText>
       )}
     </Box>
   );

--- a/packages/form-builder/src/components/FieldProperties.jsx
+++ b/packages/form-builder/src/components/FieldProperties.jsx
@@ -735,6 +735,18 @@ const FieldProperties = ({ field, onFieldUpdate }) => {
                   sx={outlinedTextFieldSx}
                 />
               ) : null}
+              <TextField
+                label="Description"
+                fullWidth
+                multiline
+                rows={2}
+                value={localField.schema?.description || ''}
+                onChange={(e) => handleSchemaUpdate({ description: e.target.value || undefined })}
+                margin="normal"
+                variant="outlined"
+                helperText="Help text displayed below the field"
+                sx={outlinedTextFieldSx}
+              />
             </Box>
           </AccordionDetails>
         </Accordion>

--- a/packages/form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/form-builder/src/controls/CustomDateControl.jsx
@@ -4,7 +4,7 @@ import { TextField } from '@mui/material';
 import { formatDate } from '../utils';
 
 const CustomDateControl = (props) => {
-  const { data, handleChange, path, label, required, errors, uischema, config } = props;
+  const { data, handleChange, path, label, required, errors, uischema, config, schema } = props;
 
   console.log('CustomDateControl props:', {
     data,
@@ -73,7 +73,9 @@ const CustomDateControl = (props) => {
           }
         }}
         error={errors && errors.length > 0}
-        helperText={errors && errors.length > 0 ? errors[0].message : undefined}
+        helperText={
+          errors && errors.length > 0 ? errors[0].message : schema?.description || undefined
+        }
         margin="normal"
         variant="outlined"
         InputLabelProps={{


### PR DESCRIPTION

## Summary

Added optional description field to form builder that displays as helper text below fields in the preview.

FieldProperties.jsx: - 
1. Added description TextField in Display Options accordion
2. Stored in schema.description

CustomDateControl.jsx:-
1. Added schema prop 
2. Display description in helperText

CustomFileUploadControl.jsx:-
1. Added schema and label props
2. Display description using FormHelperText


<img width="1120" height="737" alt="Screenshot 2026-01-09 at 12 26 38 PM" src="https://github.com/user-attachments/assets/36b0146e-b283-40e7-9f5b-942da831ea94" />

<img width="1100" height="551" alt="Screenshot 2026-01-09 at 12 27 27 PM" src="https://github.com/user-attachments/assets/ae3102d9-4414-4c97-831e-fee9a34ed713" />


## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.

## How to Test
Steps to verify (monorepo):
1. `yarn install`
4. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
5. Build library: `yarn workspace form-builder build`
6. Optional tests: `yarn workspace form-builder test`

## Checklist
- [x] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.

