### PR TITLE
feat: add readonly functionality to CustomFileUploadContro

### DIFF
--- a/apps/form-builder-basic-demo/src/controls/CustomFileUploadControl.jsx
+++ b/apps/form-builder-basic-demo/src/controls/CustomFileUploadControl.jsx
@@ -17,6 +17,7 @@ const CustomFileUploadControl = (props) => {
   // Accept images by default; allow override via uischema.options.accept
   const acceptedFileTypes = uischema?.options?.['ui:options']?.accept;
   const maxFileSize = uischema?.options?.['ui:options']?.maxSize;
+  const isReadOnly = uischema?.options?.readonly || false;
 
   function getAllowedMimes(acceptedFileTypes) {
     if (!acceptedFileTypes?.trim()) return [];
@@ -84,7 +85,9 @@ const CustomFileUploadControl = (props) => {
 
   const handleDragOver = (event) => {
     event.preventDefault();
-    setIsDragOver(true);
+    if (!isReadOnly) {
+      setIsDragOver(true);
+    }
   };
 
   const handleDragLeave = (event) => {
@@ -95,9 +98,11 @@ const CustomFileUploadControl = (props) => {
   const handleDrop = (event) => {
     event.preventDefault();
     setIsDragOver(false);
-    const file = event.dataTransfer.files?.[0];
-    if (file) {
-      handleFileSelect(file);
+    if (!isReadOnly) {
+      const file = event.dataTransfer.files?.[0];
+      if (file) {
+        handleFileSelect(file);
+      }
     }
   };
 
@@ -134,9 +139,10 @@ const CustomFileUploadControl = (props) => {
               : 'background.paper',
           p: 3,
           textAlign: 'center',
-          cursor: 'pointer',
+          cursor: isReadOnly ? 'not-allowed' : 'pointer',
+          opacity: isReadOnly ? 0.6 : 1,
           transition: 'all 0.2s ease-in-out',
-          '&:hover': {
+          '&:hover': !isReadOnly && {
             borderColor: 'primary.main',
             backgroundColor: 'action.hover',
           },
@@ -144,7 +150,7 @@ const CustomFileUploadControl = (props) => {
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        onClick={() => inputRef.current?.click()}
+        onClick={() => !isReadOnly && inputRef.current?.click()}
       >
         <input
           ref={inputRef}
@@ -152,7 +158,7 @@ const CustomFileUploadControl = (props) => {
           accept={acceptedFileTypes}
           onChange={handleFileInputChange}
           style={{ display: 'none' }}
-          disabled={isUploading}
+          disabled={isUploading || isReadOnly}
         />
 
         {hasFile ? (
@@ -161,9 +167,11 @@ const CustomFileUploadControl = (props) => {
             <Typography variant="body2" sx={{ mt: 1, color: 'success.main' }}>
               {t('common.file_uploaded_successfully')}
             </Typography>
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {t('common.click_to_change_file')}
-            </Typography>
+            {!isReadOnly && (
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {t('common.click_to_change_file')}
+              </Typography>
+            )}
           </Box>
         ) : (
           <Box>


### PR DESCRIPTION
Added readonly functionality:- 
1. Users cannot upload files when readonly is enabled
2. Visual feedback shows the field is disabled
3. Drag & drop is blocked
4. Click interactions are prevented
5. Existing uploaded files are displayed but cannot be changed


<img width="1439" height="807" alt="Screenshot 2026-01-12 at 12 02 19 PM" src="https://github.com/user-attachments/assets/10be80be-f551-49a5-9dd7-90e28cd958b2" />
<img width="1440" height="900" alt="Screenshot 2026-01-12 at 12 02 27 PM" src="https://github.com/user-attachments/assets/2915d02f-c27a-4bce-8c91-ae6bc37833f9" />


## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.

## How to Test
Steps to verify (monorepo):
1. `yarn install`
6. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
7. Build library: `yarn workspace form-builder build`
8. Optional tests: `yarn workspace form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
