### PR TITLE
feat: default date field added

### DIFF
--- a/packages/form-builder/src/components/FieldProperties.jsx
+++ b/packages/form-builder/src/components/FieldProperties.jsx
@@ -711,6 +711,54 @@ const FieldProperties = ({ field, onFieldUpdate }) => {
                     label="Include Time"
                     sx={{ mt: 1, mb: 1 }}
                   />
+
+                  {/* Default Date Value Picker */}
+                  <TextField
+                    label="Default Date Value"
+                    type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
+                    fullWidth
+                    value={(() => {
+                      const defaultDate = localField.schema?.default;
+                      if (!defaultDate) return '';
+
+                      const includeTime = localField.uischema?.options?.includeTime;
+                      if (includeTime) {
+                        const date = new Date(defaultDate);
+                        if (!isNaN(date.getTime())) {
+                          const year = date.getFullYear();
+                          const month = String(date.getMonth() + 1).padStart(2, '0');
+                          const day = String(date.getDate()).padStart(2, '0');
+                          const hours = String(date.getHours()).padStart(2, '0');
+                          const minutes = String(date.getMinutes()).padStart(2, '0');
+                          return `${year}-${month}-${day}T${hours}:${minutes}`;
+                        }
+                      }
+
+                      return defaultDate ? defaultDate.split('T')[0] : '';
+                    })()}
+                    onChange={(e) => {
+                      let dateValue = e.target.value;
+
+                      if (dateValue) {
+                        const includeTime = localField.uischema?.options?.includeTime;
+                        if (includeTime) {
+                          const date = new Date(dateValue);
+                          dateValue = date.toISOString();
+                        }
+                      } else {
+                        dateValue = undefined;
+                      }
+
+                      handleSchemaUpdate({ default: dateValue });
+                    }}
+                    margin="normal"
+                    variant="outlined"
+                    helperText="Default date value that will be pre-filled in the form"
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    sx={outlinedTextFieldSx}
+                  />
                 </>
               ) : // Default Value field for non-date fields
               localField.type !== 'array' &&

--- a/packages/form-builder/src/components/FormPreview.jsx
+++ b/packages/form-builder/src/components/FormPreview.jsx
@@ -151,9 +151,12 @@ const FormPreview = ({
       if (
         prop.default !== undefined &&
         (formState.data[key] === '' ||
+          formState.data[key] === undefined ||
+          formState.data[key] === null ||
           formState.data[key]?.length === 0 ||
           prop.type === 'boolean' ||
-          prop.type === 'number')
+          prop.type === 'number' ||
+          (prop.type === 'string' && (prop.format === 'date' || prop.format === 'datetime')))
       ) {
         formState.data[key] = prop.default;
       }


### PR DESCRIPTION
## Summary
For Date Field Type
In Field Properties - > Display Options ->
Add Default Value - user should be able to select default date from calendar
Showed Default Value of Date in Form Preview Section

## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/20ccecde-e35a-44f9-9b47-707739a9ddd5" />
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/6179ea11-e0a6-428d-bc8a-cd93914dd32e" />
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/cb2cba23-53f1-4eec-90fd-4f4bde8ac391" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace form-builder build`
4. Optional tests: `yarn workspace form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
