### PR TITLE
fix: confirm delete dropdown added on deep nesting

### DIFF
--- a/packages/form-builder/src/components/ActionButtons.jsx
+++ b/packages/form-builder/src/components/ActionButtons.jsx
@@ -218,6 +218,16 @@ const ActionButtons = ({
             <ListItemText primary="Delete" />
           </MenuItem>
         </Menu>
+        {/* Delete Confirmation Dialog */}
+        <Dialog open={confirmOpen} onClose={closeDeleteConfirm} maxWidth="xs" fullWidth>
+          <DialogTitle>Are you sure you want to delete this item?</DialogTitle>
+          <DialogActions>
+            <Button onClick={closeDeleteConfirm}>Cancel</Button>
+            <Button variant="contained" color="error" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
Dropdown for confirm delete is added for nested layout

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
The fix is for nested layout

## Screenshots
<img width="1424" height="854" alt="image" src="https://github.com/user-attachments/assets/2a93258d-720b-4ba7-aba5-af42fe0fdbc9" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace form-builder build`
4. Optional tests: `yarn workspace form-builder test`

## Checklist
- [x] Builds locally (`yarn build`)
- [x] Tests added/updated (if applicable)
- [x] Documentation updated
- [x] Linked issues

## Notes
Any additional notes for reviewers.
