### PR TITLE
feat: min max value added for date field in validation options

### DIFF
--- a/packages/form-builder/src/components/FieldProperties.jsx
+++ b/packages/form-builder/src/components/FieldProperties.jsx
@@ -18,9 +18,17 @@ import {
   Checkbox,
   RadioGroup,
   Radio,
+  InputAdornment,
 } from '@mui/material';
 import React, { useState, useEffect } from 'react';
-import { IconPlus, IconTrash, IconSettings, IconChevronDown, IconEdit } from '@tabler/icons-react';
+import {
+  IconPlus,
+  IconTrash,
+  IconSettings,
+  IconChevronDown,
+  IconEdit,
+  IconX,
+} from '@tabler/icons-react';
 
 import { defaultFieldTypes } from '../types';
 import IconSelector from '../utils/IconSelector';
@@ -805,6 +813,145 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                       margin="normal"
                       variant="outlined"
                       sx={outlinedTextFieldSx}
+                    />
+                  </Grid>
+                </Grid>
+              )}
+
+              {/* Date Range Validation */}
+              {(localField.schema?.format === 'date' ||
+                localField.schema?.format === 'date-time' ||
+                localField.schema?.format === 'datetime' ||
+                localField.type === 'date') && (
+                <Grid container spacing={2}>
+                  <Grid item xs={6}>
+                    <TextField
+                      label="Min Date"
+                      type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
+                      fullWidth
+                      value={(() => {
+                        const minDate = localField.schema?.minimum;
+                        if (!minDate) return '';
+
+                        const includeTime = localField.uischema?.options?.includeTime;
+                        if (includeTime) {
+                          const date = new Date(minDate);
+                          if (!isNaN(date.getTime())) {
+                            const year = date.getFullYear();
+                            const month = String(date.getMonth() + 1).padStart(2, '0');
+                            const day = String(date.getDate()).padStart(2, '0');
+                            const hours = String(date.getHours()).padStart(2, '0');
+                            const minutes = String(date.getMinutes()).padStart(2, '0');
+                            return `${year}-${month}-${day}T${hours}:${minutes}`;
+                          }
+                        }
+
+                        return minDate ? minDate.split('T')[0] : '';
+                      })()}
+                      onChange={(e) => {
+                        let dateValue = e.target.value;
+
+                        if (dateValue) {
+                          const includeTime = localField.uischema?.options?.includeTime;
+                          if (includeTime) {
+                            const date = new Date(dateValue);
+                            dateValue = date.toISOString();
+                          }
+                        } else {
+                          dateValue = undefined;
+                        }
+
+                        handleSchemaUpdate({ minimum: dateValue });
+                      }}
+                      margin="normal"
+                      variant="outlined"
+                      helperText="Minimum allowed date"
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                      InputProps={{
+                        endAdornment: localField.schema?.minimum && (
+                          <InputAdornment position="end">
+                            <IconButton
+                              size="small"
+                              onClick={() => handleSchemaUpdate({ minimum: undefined })}
+                              edge="end"
+                              sx={{
+                                color: 'text.secondary',
+                                '&:hover': { color: 'error.main' },
+                              }}
+                            >
+                              <IconX size={16} />
+                            </IconButton>
+                          </InputAdornment>
+                        ),
+                      }}
+                      sx={{ '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
+                    />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <TextField
+                      label="Max Date"
+                      type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
+                      fullWidth
+                      value={(() => {
+                        const maxDate = localField.schema?.maximum;
+                        if (!maxDate) return '';
+
+                        const includeTime = localField.uischema?.options?.includeTime;
+                        if (includeTime) {
+                          const date = new Date(maxDate);
+                          if (!isNaN(date.getTime())) {
+                            const year = date.getFullYear();
+                            const month = String(date.getMonth() + 1).padStart(2, '0');
+                            const day = String(date.getDate()).padStart(2, '0');
+                            const hours = String(date.getHours()).padStart(2, '0');
+                            const minutes = String(date.getMinutes()).padStart(2, '0');
+                            return `${year}-${month}-${day}T${hours}:${minutes}`;
+                          }
+                        }
+
+                        return maxDate ? maxDate.split('T')[0] : '';
+                      })()}
+                      onChange={(e) => {
+                        let dateValue = e.target.value;
+
+                        if (dateValue) {
+                          const includeTime = localField.uischema?.options?.includeTime;
+                          if (includeTime) {
+                            const date = new Date(dateValue);
+                            dateValue = date.toISOString();
+                          }
+                        } else {
+                          dateValue = undefined;
+                        }
+
+                        handleSchemaUpdate({ maximum: dateValue });
+                      }}
+                      margin="normal"
+                      variant="outlined"
+                      helperText="Maximum allowed date"
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                      InputProps={{
+                        endAdornment: localField.schema?.maximum && (
+                          <InputAdornment position="end">
+                            <IconButton
+                              size="small"
+                              onClick={() => handleSchemaUpdate({ maximum: undefined })}
+                              edge="end"
+                              sx={{
+                                color: 'text.secondary',
+                                '&:hover': { color: 'error.main' },
+                              }}
+                            >
+                              <IconX size={16} />
+                            </IconButton>
+                          </InputAdornment>
+                        ),
+                      }}
+                      sx={{ '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
                     />
                   </Grid>
                 </Grid>

--- a/packages/form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/form-builder/src/controls/CustomDateControl.jsx
@@ -9,6 +9,8 @@ const CustomDateControl = (props) => {
   const dateFormat = uischema?.options?.dateTimeFormat || 'friendly';
   const includeTime = uischema?.options?.includeTime || false;
   const isReadOnly = uischema?.options?.readonly;
+  const minDate = schema?.minimum;
+  const maxDate = schema?.maximum;
 
   const getDisplayValue = () => {
     if (!data) return '';
@@ -41,6 +43,42 @@ const CustomDateControl = (props) => {
     return includeTime ? 'datetime-local' : 'date';
   };
 
+  const getMinValue = () => {
+    if (!minDate) return undefined;
+
+    if (includeTime) {
+      const date = new Date(minDate);
+      if (!isNaN(date.getTime())) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${year}-${month}-${day}T${hours}:${minutes}`;
+      }
+    }
+
+    return minDate ? minDate.split('T')[0] : undefined;
+  };
+
+  const getMaxValue = () => {
+    if (!maxDate) return undefined;
+
+    if (includeTime) {
+      const date = new Date(maxDate);
+      if (!isNaN(date.getTime())) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${year}-${month}-${day}T${hours}:${minutes}`;
+      }
+    }
+
+    return maxDate ? maxDate.split('T')[0] : undefined;
+  };
+
   const formattedDisplay = getFormattedDisplayText();
 
   return (
@@ -51,9 +89,15 @@ const CustomDateControl = (props) => {
         fullWidth
         required={required}
         value={getDisplayValue()}
+        min={getMinValue()}
+        max={getMaxValue()}
         placeholder={undefined}
         InputProps={{
           placeholder: undefined,
+        }}
+        inputProps={{
+          min: getMinValue(),
+          max: getMaxValue(),
         }}
         onChange={(e) => {
           if (!isReadOnly) {


### PR DESCRIPTION
## Summary
In Date Field For Validation Option added Min and MAx date Selection
1. You can select only min date
2. You can also select only max date
3. Select both dates min and max
4. or select None 

Cross Icon is given to reset the date

## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/8d520e38-0f45-4042-ac88-e847857f68a5" />
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/53d18e51-6ea5-4f2a-a4c7-561cf49e1d77" />
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/d435e0cd-818f-4e79-8cfe-fa91eb745bbe" />


## How to Test
Steps to verify (monorepo):
1. `yarn install`
3. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
5. Build library: `yarn workspace form-builder build`
6. Optional tests: `yarn workspace form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
