### PR TITLE
Bug 1210: Bug fixed for save button, read only date, capitalize enum

### DIFF
--- a/packages/form-builder/src/App.jsx
+++ b/packages/form-builder/src/App.jsx
@@ -297,6 +297,10 @@ const App = ({ onExport, onSave, schemas = [], theme: customTheme } = {}) => {
   );
 
   const handleFieldUpdate = useCallback((updatedField, options = {}) => {
+    if (updatedField?.defaultvalueUpdate) {
+      setHasUnsavedChanges(true);
+      return;
+    }
     setEditingField(updatedField);
     setHasUnsavedChanges(true);
 

--- a/packages/form-builder/src/components/FieldProperties.jsx
+++ b/packages/form-builder/src/components/FieldProperties.jsx
@@ -528,7 +528,6 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
 
   const optionChipSx = {
     borderRadius: 1.5,
-    textTransform: 'capitalize',
     '& .MuiChip-deleteIcon': {
       color: 'error.main',
       '&:hover': {
@@ -879,6 +878,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                   value={defaultInput}
                   onChange={(e) => {
                     setDefaultInput(e.target.value);
+                    onFieldUpdate({ defaultvalueUpdate: true });
                   }}
                   onBlur={(e) => {
                     let defaultValue = e.target.value;

--- a/packages/form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/form-builder/src/controls/CustomDateControl.jsx
@@ -40,7 +40,14 @@ const CustomDateControl = (props) => {
   };
 
   const getInputType = () => {
-    return includeTime ? 'datetime-local' : 'date';
+    if (isReadOnly) {
+      return 'text';
+    }
+    if (includeTime) {
+      return 'datetime-local';
+    }
+    return 'date';
+    //return includeTime ? 'datetime-local' : 'date';
   };
 
   const getMinValue = () => {


### PR DESCRIPTION
## Summary
Bug fixed for save button, read only date, capitalize enum

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.
<img width="1440" height="688" alt="Screenshot 2026-01-14 at 2 06 55 PM" src="https://github.com/user-attachments/assets/16d774eb-4b36-4ad6-980e-eb52d7c9e25c" />
<img width="1440" height="688" alt="Screenshot 2026-01-14 at 2 07 13 PM" src="https://github.com/user-attachments/assets/96745792-c85c-4c0f-ab1c-720951336144" />
<img width="1440" height="688" alt="Screenshot 2026-01-14 at 2 10 29 PM" src="https://github.com/user-attachments/assets/b9decc9b-084a-4eb8-82cc-b705b93c0bf6" />
<img width="1440" height="688" alt="Screenshot 2026-01-14 at 2 11 26 PM" src="https://github.com/user-attachments/assets/9e4b839d-5520-4739-ace3-c3ed98eed18f" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace form-builder build`
4. Optional tests: `yarn workspace form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
