### PR TITLE
fix: added unique item for array type

### DIFF
--- a/packages/form-builder/src/lib/schema/buildSchema.js
+++ b/packages/form-builder/src/lib/schema/buildSchema.js
@@ -8,6 +8,7 @@ export const buildSchemaFromFields = (fieldsArray, parentKey = null) => {
       properties[field.key] = {
         type: 'array',
         title: field.label,
+        uniqueItems: true,
         ...Object.fromEntries(Object.entries(field.schema || {}).filter(([key]) => key !== 'type')),
       };
 

--- a/packages/form-builder/src/types.js
+++ b/packages/form-builder/src/types.js
@@ -278,6 +278,7 @@ export const defaultFieldTypes = [
       items: {
         type: 'string',
       },
+      uniqueItems: true,
     },
     uischema: {
       type: 'Control',
@@ -300,6 +301,7 @@ export const defaultFieldTypes = [
       items: {
         type: 'string',
       },
+      uniqueItems: true,
     },
     uischema: {
       type: 'Control',


### PR DESCRIPTION
## Summary
Added unique item property for array type
User can not add same items in the array and will get error message

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
User should not add same items inside array

## Screenshots
<img width="1427" height="782" alt="image" src="https://github.com/user-attachments/assets/18de0a96-a35c-45aa-a43a-03d5250aeb0a" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run form-builder-basic-demo: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace form-builder build`
4. Optional tests: `yarn workspace form-builder test`

## Checklist
- [x] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [x] Linked issues

## Notes
