### PR TITLE
Feature/1123 : Add reset and clear all functionality to form builder

### DIFF
--- a/packages/react-form-builder/src/components/CommonHeader.jsx
+++ b/packages/react-form-builder/src/components/CommonHeader.jsx
@@ -1,4 +1,4 @@
-import { IconEye, IconCode, IconRestore, IconTrash } from '@tabler/icons-react';
+import { IconEye, IconCode } from '@tabler/icons-react';
 import { Box, Typography, Button, ButtonGroup } from '@mui/material';
 
 const headerContainerSx = {
@@ -61,10 +61,6 @@ const CommonHeader = ({
   setShowFormPreview,
   showSchemaEditor,
   setShowSchemaEditor,
-  onReset,
-  hasOriginalSchema,
-  onClearAll,
-  hasFields,
 }) => {
   return (
     <Box sx={headerContainerSx}>
@@ -110,21 +106,6 @@ const CommonHeader = ({
             >
               Schema
             </Button>
-
-            {hasOriginalSchema ? (
-              <Button onClick={onReset} variant="outlined" startIcon={<IconRestore size={16} />}>
-                Reset
-              </Button>
-            ) : hasFields && onClearAll ? (
-              <Button
-                onClick={onClearAll}
-                variant="outlined"
-                color="error"
-                startIcon={<IconTrash size={16} />}
-              >
-                Clear All
-              </Button>
-            ) : null}
           </ButtonGroup>
         </Box>
       </Box>

--- a/packages/react-form-builder/src/components/FormStructure.jsx
+++ b/packages/react-form-builder/src/components/FormStructure.jsx
@@ -14,7 +14,7 @@ import {
 } from '@tabler/icons-react';
 import { Fragment, useState } from 'react';
 import * as TablerIcons from '@tabler/icons-react';
-import { Box, Paper, Typography, Chip, useTheme } from '@mui/material';
+import { Box, Paper, Typography, Chip, useTheme, Button } from '@mui/material';
 import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 import ContextMenu from './ContextMenu';
@@ -514,7 +514,26 @@ const FormStructure = ({
     onFieldsChange(newFields);
   };
 
-  const nestedBox = { p: { xs: 1, sm: 2 } };
+  const nestedBox = {
+    p: { xs: 1, sm: 2 },
+    paddingBottom: hasOriginalSchema || fields.length > 0 ? '80px' : '0',
+  };
+
+  const actionBox = {
+    position: 'fixed',
+    bottom: 0,
+    left: { xs: 0, md: 320 },
+    width: { xs: '100%', md: `calc(100% - 320px)` },
+    height: 64,
+    backgroundColor: 'background.paper',
+    borderTop: '1px solid',
+    borderColor: 'grey.200',
+    zIndex: (theme) => theme.zIndex.drawer + 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    px: 3,
+  };
 
   return (
     <Box>
@@ -527,10 +546,6 @@ const FormStructure = ({
         showSchemaEditor={showSchemaEditor}
         setShowSchemaEditor={setShowSchemaEditor}
         exportForm={exportForm}
-        onReset={onReset}
-        hasOriginalSchema={hasOriginalSchema}
-        onClearAll={onClearAll}
-        hasFields={fields.length > 0}
       />
 
       <Box sx={nestedBox}>
@@ -569,6 +584,20 @@ const FormStructure = ({
           </SortableContext>
         )}
       </Box>
+
+      {(hasOriginalSchema || fields.length > 0) && (
+        <Box sx={actionBox}>
+          {hasOriginalSchema ? (
+            <Button onClick={onReset} variant="contained">
+              Reset
+            </Button>
+          ) : (
+            <Button onClick={onClearAll} variant="contained" color="error">
+              Clear All
+            </Button>
+          )}
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Add Reset button to restore loaded schema to original state
- Add Clear All button to clear manually built forms
- Store original schema when loading from template
- Reset button shows when schema is loaded from template
- Clear All button shows when building form manually via drag-drop
- Both buttons positioned at bottom and there position is fixed 

## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1440" height="778" alt="Screenshot 2026-01-20 at 2 11 55 PM" src="https://github.com/user-attachments/assets/3055a029-0ef0-4eea-9fd9-275e3033f5e7" />
<img width="1439" height="776" alt="Screenshot 2026-01-20 at 2 12 20 PM" src="https://github.com/user-attachments/assets/6e52efae-0e46-4238-8669-bb585e67c409" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
