### PR TITLE
fix: remove unnecessary margin prop from CustomPasswordControl

### DIFF
--- a/packages/react-form-builder/src/controls/CustomPasswordControl.jsx
+++ b/packages/react-form-builder/src/controls/CustomPasswordControl.jsx
@@ -32,7 +32,6 @@ const CustomPasswordControl = ({
       required={required}
       variant="outlined"
       fullWidth
-      margin="normal"
       style={{ display: visible ? 'block' : 'none' }}
       InputProps={{
         endAdornment: (


### PR DESCRIPTION
Remove unnecessary margin prop from CustomPasswordControl

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1440" height="812" alt="Screenshot 2026-01-21 at 5 06 23 PM" src="https://github.com/user-attachments/assets/f1efc1e4-bfec-416a-aa52-b49fcae801a8" />


## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
