### PR TITLE
feat: add autocomplete feature for multiselect

### DIFF
--- a/packages/react-form-builder/src/controls/CustomSelectControl.jsx
+++ b/packages/react-form-builder/src/controls/CustomSelectControl.jsx
@@ -3,16 +3,18 @@ import { Unwrapped } from '@jsonforms/material-renderers';
 import { and, isControl, optionIs, rankWith } from '@jsonforms/core';
 import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
+  Box,
   Chip,
   Select,
+  Checkbox,
   MenuItem,
+  TextField,
+  FormLabel,
   InputLabel,
   FormControl,
-  Box,
-  FormLabel,
-  FormControlLabel,
-  Checkbox,
+  Autocomplete,
   FormHelperText,
+  FormControlLabel,
 } from '@mui/material';
 
 import { updateNestedValue } from '../utils';
@@ -73,7 +75,30 @@ const CustomSelectControl = (props) => {
   }, [path, schema.title]);
 
   return multi ? (
-    displayType === 'checkbox' ? (
+    displayType === 'autocomplete' || uischema.options?.autocomplete ? (
+      <FormControl fullWidth error={hasError}>
+        <Autocomplete
+          multiple
+          disabled={isReadOnly}
+          options={options}
+          getOptionLabel={(opt) => opt.label}
+          value={options.filter((o) => Array.isArray(data) && data.includes(o.value))}
+          onChange={(_e, newValues) => {
+            const selectedVals = newValues.map((v) => v.value);
+            handleOnChange(_e, selectedVals);
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={fieldLabel}
+              error={hasError}
+              helperText={validationError}
+            />
+          )}
+          {...(uischema.options?.autocompleteProps || {})}
+        />
+      </FormControl>
+    ) : displayType === 'checkbox' ? (
       <FormControl fullWidth error={hasError}>
         <FormLabel>{fieldLabel}</FormLabel>
         <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, flexWrap: 'wrap' }}>

--- a/packages/react-form-builder/src/types.js
+++ b/packages/react-form-builder/src/types.js
@@ -262,7 +262,8 @@ export const defaultFieldTypes = [
       options: {
         multi: true,
         format: 'select',
-        displayType: 'dropdown',
+        autocomplete: true,
+        displayType: 'autocomplete',
         autocompleteProps: {
           limitTags: 5,
         },


### PR DESCRIPTION
## Summary
1. Add display type as a autocomplete and autocomplete : true in multiselect Ui schema 
2. Add function based on autocomplele condition for multi true 


## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1440" height="780" alt="Screenshot 2026-01-27 at 12 08 04 PM" src="https://github.com/user-attachments/assets/d5f6f7b9-b5e4-461f-8119-1f9a0d83e8b1" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
4. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
5. Build library: `yarn workspace react-form-builder build`
6. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
