### PR TITLE
fix: Add date validation constraints and auto-clear invalid defaults

### DIFF
--- a/packages/react-form-builder/src/components/FieldProperties.jsx
+++ b/packages/react-form-builder/src/components/FieldProperties.jsx
@@ -938,6 +938,42 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
 
                         handleSchemaUpdate({ default: dateValue });
                       }}
+                      inputProps={{
+                        min: (() => {
+                          const minDate = localField.schema?.minimum;
+                          if (!minDate) return undefined;
+                          const includeTime = localField.uischema?.options?.includeTime;
+                          if (includeTime) {
+                            const date = new Date(minDate);
+                            if (!isNaN(date.getTime())) {
+                              const year = date.getFullYear();
+                              const month = String(date.getMonth() + 1).padStart(2, '0');
+                              const day = String(date.getDate()).padStart(2, '0');
+                              const hours = String(date.getHours()).padStart(2, '0');
+                              const minutes = String(date.getMinutes()).padStart(2, '0');
+                              return `${year}-${month}-${day}T${hours}:${minutes}`;
+                            }
+                          }
+                          return minDate ? minDate.split('T')[0] : undefined;
+                        })(),
+                        max: (() => {
+                          const maxDate = localField.schema?.maximum;
+                          if (!maxDate) return undefined;
+                          const includeTime = localField.uischema?.options?.includeTime;
+                          if (includeTime) {
+                            const date = new Date(maxDate);
+                            if (!isNaN(date.getTime())) {
+                              const year = date.getFullYear();
+                              const month = String(date.getMonth() + 1).padStart(2, '0');
+                              const day = String(date.getDate()).padStart(2, '0');
+                              const hours = String(date.getHours()).padStart(2, '0');
+                              const minutes = String(date.getMinutes()).padStart(2, '0');
+                              return `${year}-${month}-${day}T${hours}:${minutes}`;
+                            }
+                          }
+                          return maxDate ? maxDate.split('T')[0] : undefined;
+                        })(),
+                      }}
                       margin="normal"
                       variant="outlined"
                       helperText="Default date value that will be pre-filled in the form"
@@ -971,10 +1007,18 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                 return defaultDate ? defaultDate.split('T')[0] : '';
                               })()}
                               inputProps={{
+                                min: (() => {
+                                  const minStartDate =
+                                    localField.schema?.properties?.startDate?.minimum;
+                                  return minStartDate ? minStartDate.split('T')[0] : undefined;
+                                })(),
                                 max: (() => {
                                   const endDateDefault =
                                     localField.schema?.properties?.endDate?.default;
-                                  return endDateDefault ? endDateDefault.split('T')[0] : undefined;
+                                  const maxEndDate =
+                                    localField.schema?.properties?.endDate?.maximum;
+                                  if (endDateDefault) return endDateDefault.split('T')[0];
+                                  return maxEndDate ? maxEndDate.split('T')[0] : undefined;
                                 })(),
                               }}
                               onChange={(e) => {
@@ -1019,9 +1063,15 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                 min: (() => {
                                   const startDateDefault =
                                     localField.schema?.properties?.startDate?.default;
-                                  return startDateDefault
-                                    ? startDateDefault.split('T')[0]
-                                    : undefined;
+                                  const minStartDate =
+                                    localField.schema?.properties?.startDate?.minimum;
+                                  if (startDateDefault) return startDateDefault.split('T')[0];
+                                  return minStartDate ? minStartDate.split('T')[0] : undefined;
+                                })(),
+                                max: (() => {
+                                  const maxEndDate =
+                                    localField.schema?.properties?.endDate?.maximum;
+                                  return maxEndDate ? maxEndDate.split('T')[0] : undefined;
                                 })(),
                               }}
                               onChange={(e) => {
@@ -1700,6 +1750,35 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           }
 
                           handleSchemaUpdate({ minimum: dateValue });
+
+                          // Clear default if it's now invalid
+                          const currentDefault = localField.schema?.default;
+                          if (
+                            currentDefault &&
+                            dateValue &&
+                            new Date(currentDefault) < new Date(dateValue)
+                          ) {
+                            handleSchemaUpdate({ minimum: dateValue, default: undefined });
+                          }
+                        }}
+                        inputProps={{
+                          max: (() => {
+                            const maxDate = localField.schema?.maximum;
+                            if (!maxDate) return undefined;
+                            const includeTime = localField.uischema?.options?.includeTime;
+                            if (includeTime) {
+                              const date = new Date(maxDate);
+                              if (!isNaN(date.getTime())) {
+                                const year = date.getFullYear();
+                                const month = String(date.getMonth() + 1).padStart(2, '0');
+                                const day = String(date.getDate()).padStart(2, '0');
+                                const hours = String(date.getHours()).padStart(2, '0');
+                                const minutes = String(date.getMinutes()).padStart(2, '0');
+                                return `${year}-${month}-${day}T${hours}:${minutes}`;
+                              }
+                            }
+                            return maxDate ? maxDate.split('T')[0] : undefined;
+                          })(),
                         }}
                         margin="normal"
                         variant="outlined"
@@ -1733,7 +1812,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                         type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
                         fullWidth
                         value={(() => {
-                          const maxDate = localField.uischema?.options?.maxDate;
+                          const maxDate = localField.schema?.maximum;
                           if (!maxDate) return '';
 
                           const includeTime = localField.uischema?.options?.includeTime;
@@ -1768,6 +1847,35 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           }
 
                           handleSchemaUpdate({ maximum: dateValue });
+
+                          // Clear default if it's now invalid
+                          const currentDefault = localField.schema?.default;
+                          if (
+                            currentDefault &&
+                            dateValue &&
+                            new Date(currentDefault) > new Date(dateValue)
+                          ) {
+                            handleSchemaUpdate({ maximum: dateValue, default: undefined });
+                          }
+                        }}
+                        inputProps={{
+                          min: (() => {
+                            const minDate = localField.schema?.minimum;
+                            if (!minDate) return undefined;
+                            const includeTime = localField.uischema?.options?.includeTime;
+                            if (includeTime) {
+                              const date = new Date(minDate);
+                              if (!isNaN(date.getTime())) {
+                                const year = date.getFullYear();
+                                const month = String(date.getMonth() + 1).padStart(2, '0');
+                                const day = String(date.getDate()).padStart(2, '0');
+                                const hours = String(date.getHours()).padStart(2, '0');
+                                const minutes = String(date.getMinutes()).padStart(2, '0');
+                                return `${year}-${month}-${day}T${hours}:${minutes}`;
+                              }
+                            }
+                            return minDate ? minDate.split('T')[0] : undefined;
+                          })(),
                         }}
                         margin="normal"
                         variant="outlined"
@@ -1807,10 +1915,10 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                       Date Range Validation
                     </Typography>
                     <Grid container spacing={2}>
-                      {/* Start Date Min */}
+                      {/* Min Date */}
                       <Grid item xs={6}>
                         <TextField
-                          label="Min Start Date"
+                          label="Min Date"
                           type="date"
                           fullWidth
                           value={(() => {
@@ -1825,19 +1933,52 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             } else {
                               dateValue = undefined;
                             }
-                            handleSchemaUpdate({
+
+                            const updates = {
                               properties: {
                                 ...localField.schema.properties,
                                 startDate: {
                                   ...localField.schema.properties.startDate,
                                   minimum: dateValue,
                                 },
+                                endDate: {
+                                  ...localField.schema.properties.endDate,
+                                  minimum: dateValue,
+                                },
                               },
-                            });
+                            };
+
+                            // Clear defaults if they become invalid
+                            const defaultStartDate =
+                              localField.schema?.properties?.startDate?.default;
+                            const defaultEndDate = localField.schema?.properties?.endDate?.default;
+
+                            if (
+                              defaultStartDate &&
+                              dateValue &&
+                              new Date(defaultStartDate) < new Date(dateValue)
+                            ) {
+                              updates.properties.startDate.default = undefined;
+                            }
+                            if (
+                              defaultEndDate &&
+                              dateValue &&
+                              new Date(defaultEndDate) < new Date(dateValue)
+                            ) {
+                              updates.properties.endDate.default = undefined;
+                            }
+
+                            handleSchemaUpdate(updates);
+                          }}
+                          inputProps={{
+                            max: (() => {
+                              const maxEndDate = localField.schema?.properties?.endDate?.maximum;
+                              return maxEndDate ? maxEndDate.split('T')[0] : undefined;
+                            })(),
                           }}
                           margin="normal"
                           variant="outlined"
-                          helperText="Earliest allowed start date"
+                          helperText="Earliest allowed date for both start and end dates"
                           InputLabelProps={{
                             shrink: true,
                           }}
@@ -1852,6 +1993,10 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                         ...localField.schema.properties,
                                         startDate: {
                                           ...localField.schema.properties.startDate,
+                                          minimum: undefined,
+                                        },
+                                        endDate: {
+                                          ...localField.schema.properties.endDate,
                                           minimum: undefined,
                                         },
                                       },
@@ -1872,10 +2017,10 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                         />
                       </Grid>
 
-                      {/* End Date Max */}
+                      {/* Max Date */}
                       <Grid item xs={6}>
                         <TextField
-                          label="Max End Date"
+                          label="Max Date"
                           type="date"
                           fullWidth
                           value={(() => {
@@ -1890,19 +2035,53 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             } else {
                               dateValue = undefined;
                             }
-                            handleSchemaUpdate({
+
+                            const updates = {
                               properties: {
                                 ...localField.schema.properties,
+                                startDate: {
+                                  ...localField.schema.properties.startDate,
+                                  maximum: dateValue,
+                                },
                                 endDate: {
                                   ...localField.schema.properties.endDate,
                                   maximum: dateValue,
                                 },
                               },
-                            });
+                            };
+
+                            // Clear defaults if they become invalid
+                            const defaultStartDate =
+                              localField.schema?.properties?.startDate?.default;
+                            const defaultEndDate = localField.schema?.properties?.endDate?.default;
+
+                            if (
+                              defaultStartDate &&
+                              dateValue &&
+                              new Date(defaultStartDate) > new Date(dateValue)
+                            ) {
+                              updates.properties.startDate.default = undefined;
+                            }
+                            if (
+                              defaultEndDate &&
+                              dateValue &&
+                              new Date(defaultEndDate) > new Date(dateValue)
+                            ) {
+                              updates.properties.endDate.default = undefined;
+                            }
+
+                            handleSchemaUpdate(updates);
+                          }}
+                          inputProps={{
+                            min: (() => {
+                              const minStartDate =
+                                localField.schema?.properties?.startDate?.minimum;
+                              return minStartDate ? minStartDate.split('T')[0] : undefined;
+                            })(),
                           }}
                           margin="normal"
                           variant="outlined"
-                          helperText="Latest allowed end date"
+                          helperText="Latest allowed date for both start and end dates"
                           InputLabelProps={{
                             shrink: true,
                           }}
@@ -1915,6 +2094,10 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                     handleSchemaUpdate({
                                       properties: {
                                         ...localField.schema.properties,
+                                        startDate: {
+                                          ...localField.schema.properties.startDate,
+                                          maximum: undefined,
+                                        },
                                         endDate: {
                                           ...localField.schema.properties.endDate,
                                           maximum: undefined,

--- a/packages/react-form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/react-form-builder/src/controls/CustomDateControl.jsx
@@ -246,8 +246,6 @@ const CustomDateControl = (props) => {
         fullWidth
         required={required}
         value={getDisplayValue()}
-        min={getMinValue()}
-        max={getMaxValue()}
         placeholder={undefined}
         InputProps={{
           placeholder: undefined,


### PR DESCRIPTION

Add date validation constraints and auto-clear invalid default values when validation rules change

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots

<img width="1120" height="806" alt="Screenshot 2026-01-28 at 4 13 14 PM" src="https://github.com/user-attachments/assets/6df2cacf-6d0e-42d5-ab36-3158ee655228" />

<img width="1135" height="805" alt="Screenshot 2026-01-28 at 4 13 29 PM" src="https://github.com/user-attachments/assets/eef16007-3af3-4535-8160-c2d23f76fbd5" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
