### PR TITLE
fix: file upload type fixed

### DIFF
--- a/packages/react-form-builder/src/components/FieldProperties.jsx
+++ b/packages/react-form-builder/src/components/FieldProperties.jsx
@@ -327,6 +327,17 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
         };
       }
 
+      // Detect file upload fields and correct their type for display
+      if (
+        updatedField.schema?.format === 'data-url' ||
+        (updatedField.uischema?.options && updatedField.uischema.options['ui:widget'] === 'file')
+      ) {
+        updatedField = {
+          ...updatedField,
+          type: 'file',
+        };
+      }
+
       setLocalField(updatedField);
       if (field.isLayout) {
         setLayout(field.type);
@@ -506,6 +517,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
       localField.schema?.type === 'object' &&
       localField.schema?.properties?.startDate &&
       localField.schema?.properties?.endDate;
+
+    // File upload fields should show file type option
+    if (localField.type === 'file') {
+      return availableFieldTypes.filter((ft) => ft.id === 'file');
+    }
 
     // Array fields with enum items (multiselect) can switch between multiselect types and array
     if (currentSchemaType === 'array' && localField.schema?.items?.enum) {

--- a/packages/react-form-builder/src/lib/schema/convert.js
+++ b/packages/react-form-builder/src/lib/schema/convert.js
@@ -17,6 +17,9 @@ export const mapSchemaPropertyToFieldType = (property, defaultFieldTypes) => {
       if (format === 'date' || format === 'date-time') {
         return defaultFieldTypes.find((ft) => ft.id === 'date') || defaultFieldTypes[0];
       }
+      if (format === 'data-url') {
+        return defaultFieldTypes.find((ft) => ft.id === 'file') || defaultFieldTypes[0];
+      }
       if (maxLength && maxLength > 100) {
         return defaultFieldTypes.find((ft) => ft.id === 'textarea') || defaultFieldTypes[0];
       }


### PR DESCRIPTION
## Summary
Bug: file upload type fixed
## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1422" height="854" alt="image" src="https://github.com/user-attachments/assets/ed27d021-11f7-4229-905c-c543a2c5e24f" />
## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
