### PR TITLE
Feat-1251: Added toggle UI for Textarea

### DIFF
--- a/examples/react-form-builder-basic/src/locales/es.json
+++ b/examples/react-form-builder-basic/src/locales/es.json
@@ -62,6 +62,7 @@
   "selectFileTypes": "Selecciona tipos de archivo",
   "enumValues": "Valores enumerados",
   "enableMultiSelect": "Habilitar selección múltiple",
+  "enableTextarea": "Habilitar área de texto",
   "apiEntity": "Entidad de API",
   "apiEntityHelp": "Nombre del endpoint de la API (p. ej., countries, cities)",
   "valueFieldName": "Nombre del campo de valor",

--- a/packages/react-form-builder/src/components/FieldProperties.jsx
+++ b/packages/react-form-builder/src/components/FieldProperties.jsx
@@ -847,6 +847,33 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
               />
             )}
 
+            {/* Textarea toggle for text fields */}
+            {localField.type === 'text' && (
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={localField.uischema?.options?.multi === true}
+                    onChange={(e) => {
+                      const isMulti = e.target.checked;
+                      let updatedUISchema = { ...localField.uischema };
+
+                      updatedUISchema.options = {
+                        ...updatedUISchema.options,
+                        multi: isMulti,
+                      };
+
+                      handleUpdate({
+                        uischema: updatedUISchema,
+                      });
+                    }}
+                    color="primary"
+                  />
+                }
+                label={t('enableTextarea')}
+                sx={{ mb: 2, display: 'block' }}
+              />
+            )}
+
             {isGroup && (
               <>
                 <TextField
@@ -2237,7 +2264,6 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
 
             <Box>
               {(localField.type === 'text' ||
-                localField.type === 'textarea' ||
                 localField.type === 'password' ||
                 localField.type === 'url') && (
                 <>

--- a/packages/react-form-builder/src/i18n/locales/en.json
+++ b/packages/react-form-builder/src/i18n/locales/en.json
@@ -62,6 +62,7 @@
   "selectFileTypes": "Select file types",
   "enumValues": "Enum Values",
   "enableMultiSelect": "Enable Multi-Select",
+  "enableTextarea": "Enable Textarea",
   "apiEntity": "API Entity",
   "apiEntityHelp": "API endpoint name (e.g., countries, cities)",
   "valueFieldName": "Value Field Name",

--- a/packages/react-form-builder/src/types.js
+++ b/packages/react-form-builder/src/types.js
@@ -99,7 +99,7 @@ export const defaultFieldTypes = [
     type: 'string',
     labelKey: 'fieldType_text',
     translationKey: 'fieldType_text',
-    label: 'Text Input',
+    label: 'Text',
     icon: IconEdit,
     schema: {
       type: 'string',
@@ -107,8 +107,10 @@ export const defaultFieldTypes = [
     uischema: {
       type: 'Control',
       scope: '#/properties/field',
+      options: {
+        multi: false,
+      },
     },
-    textType: 'text', // Default to single line text
   },
   {
     id: 'email',


### PR DESCRIPTION

Added toggle UI :- "Enable Textarea" switch in FieldProperties that sets test input field to textarea input field.

<img width="1125" height="815" alt="Screenshot 2026-02-06 at 1 01 24 PM" src="https://github.com/user-attachments/assets/21295f6c-609d-4959-8b33-ddf30c6588d3" />

<img width="1440" height="813" alt="Screenshot 2026-02-06 at 1 01 56 PM" src="https://github.com/user-attachments/assets/7f88883e-4e63-417b-8fef-70f7197b4da9" />


## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.

## How to Test
Steps to verify (monorepo):
1. `yarn install`
3. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
4. Build library: `yarn workspace react-form-builder build`
5. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
