### PR TITLE
Add formatMinimum and formatMaximum keywords to validation and update related components

### DIFF
--- a/packages/react-form-builder/src/components/FieldProperties.jsx
+++ b/packages/react-form-builder/src/components/FieldProperties.jsx
@@ -1291,8 +1291,10 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
 
                         // Reset values
                         updatedSchema.default = undefined;
-                        updatedSchema.minimum = undefined;
-                        updatedSchema.maximum = undefined;
+                        updatedSchema.formatMinimum = undefined;
+                        updatedSchema.formatMaximum = undefined;
+                        delete updatedSchema.minimum;
+                        delete updatedSchema.maximum;
 
                         if (type === 'date') {
                           // Simple date
@@ -1482,7 +1484,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                       }}
                       inputProps={{
                         min: (() => {
-                          const minDate = localField.schema?.minimum;
+                          const minDate = localField.schema?.formatMinimum;
                           if (!minDate) return undefined;
                           const includeTime = localField.uischema?.options?.includeTime;
                           if (includeTime) {
@@ -1499,7 +1501,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           return minDate ? minDate.split('T')[0] : undefined;
                         })(),
                         max: (() => {
-                          const maxDate = localField.schema?.maximum;
+                          const maxDate = localField.schema?.formatMaximum;
                           if (!maxDate) return undefined;
                           const includeTime = localField.uischema?.options?.includeTime;
                           if (includeTime) {
@@ -1551,14 +1553,14 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                               inputProps={{
                                 min: (() => {
                                   const minStartDate =
-                                    localField.schema?.properties?.startDate?.minimum;
+                                    localField.schema?.properties?.startDate?.formatMinimum;
                                   return minStartDate ? minStartDate.split('T')[0] : undefined;
                                 })(),
                                 max: (() => {
                                   const endDateDefault =
                                     localField.schema?.properties?.endDate?.default;
                                   const maxEndDate =
-                                    localField.schema?.properties?.endDate?.maximum;
+                                    localField.schema?.properties?.endDate?.formatMaximum;
                                   if (endDateDefault) return endDateDefault.split('T')[0];
                                   return maxEndDate ? maxEndDate.split('T')[0] : undefined;
                                 })(),
@@ -1633,13 +1635,13 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                   const startDateDefault =
                                     localField.schema?.properties?.startDate?.default;
                                   const minStartDate =
-                                    localField.schema?.properties?.startDate?.minimum;
+                                    localField.schema?.properties?.startDate?.formatMinimum;
                                   if (startDateDefault) return startDateDefault.split('T')[0];
                                   return minStartDate ? minStartDate.split('T')[0] : undefined;
                                 })(),
                                 max: (() => {
                                   const maxEndDate =
-                                    localField.schema?.properties?.endDate?.maximum;
+                                    localField.schema?.properties?.endDate?.formatMaximum;
                                   return maxEndDate ? maxEndDate.split('T')[0] : undefined;
                                 })(),
                               }}
@@ -2358,7 +2360,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                         type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
                         fullWidth
                         value={(() => {
-                          const minDate = localField.schema?.minimum;
+                          const minDate = localField.schema?.formatMinimum;
                           if (!minDate) return '';
 
                           const includeTime = localField.uischema?.options?.includeTime;
@@ -2392,7 +2394,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             dateValue = undefined;
                           }
 
-                          handleSchemaUpdate({ minimum: dateValue });
+                          handleSchemaUpdate({ formatMinimum: dateValue });
 
                           // Clear default if it's now invalid
                           const currentDefault = localField.schema?.default;
@@ -2401,12 +2403,12 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             dateValue &&
                             new Date(currentDefault) < new Date(dateValue)
                           ) {
-                            handleSchemaUpdate({ minimum: dateValue, default: undefined });
+                            handleSchemaUpdate({ formatMinimum: dateValue, default: undefined });
                           }
                         }}
                         inputProps={{
                           max: (() => {
-                            const maxDate = localField.schema?.maximum;
+                            const maxDate = localField.schema?.formatMaximum;
                             if (!maxDate) return undefined;
                             const includeTime = localField.uischema?.options?.includeTime;
                             if (includeTime) {
@@ -2430,11 +2432,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           shrink: true,
                         }}
                         InputProps={{
-                          endAdornment: localField.schema?.minimum && (
+                          endAdornment: localField.schema?.formatMinimum && (
                             <InputAdornment position="end">
                               <IconButton
                                 size="small"
-                                onClick={() => handleSchemaUpdate({ minimum: undefined })}
+                                onClick={() => handleSchemaUpdate({ formatMinimum: undefined })}
                                 edge="end"
                                 sx={{
                                   color: 'text.secondary',
@@ -2455,7 +2457,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                         type={localField.uischema?.options?.includeTime ? 'datetime-local' : 'date'}
                         fullWidth
                         value={(() => {
-                          const maxDate = localField.schema?.maximum;
+                          const maxDate = localField.schema?.formatMaximum;
                           if (!maxDate) return '';
 
                           const includeTime = localField.uischema?.options?.includeTime;
@@ -2489,7 +2491,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             dateValue = undefined;
                           }
 
-                          handleSchemaUpdate({ maximum: dateValue });
+                          handleSchemaUpdate({ formatMaximum: dateValue });
 
                           // Clear default if it's now invalid
                           const currentDefault = localField.schema?.default;
@@ -2498,12 +2500,12 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             dateValue &&
                             new Date(currentDefault) > new Date(dateValue)
                           ) {
-                            handleSchemaUpdate({ maximum: dateValue, default: undefined });
+                            handleSchemaUpdate({ formatMaximum: dateValue, default: undefined });
                           }
                         }}
                         inputProps={{
                           min: (() => {
-                            const minDate = localField.schema?.minimum;
+                            const minDate = localField.schema?.formatMinimum;
                             if (!minDate) return undefined;
                             const includeTime = localField.uischema?.options?.includeTime;
                             if (includeTime) {
@@ -2527,11 +2529,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           shrink: true,
                         }}
                         InputProps={{
-                          endAdornment: localField.schema?.maximum && (
+                          endAdornment: localField.schema?.formatMaximum && (
                             <InputAdornment position="end">
                               <IconButton
                                 size="small"
-                                onClick={() => handleSchemaUpdate({ maximum: undefined })}
+                                onClick={() => handleSchemaUpdate({ formatMaximum: undefined })}
                                 edge="end"
                                 sx={{
                                   color: 'text.secondary',
@@ -2565,7 +2567,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           type="date"
                           fullWidth
                           value={(() => {
-                            const minDate = localField.schema?.properties?.startDate?.minimum;
+                            const minDate = localField.schema?.properties?.startDate?.formatMinimum;
                             return minDate ? minDate.split('T')[0] : '';
                           })()}
                           onChange={(e) => {
@@ -2582,11 +2584,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                 ...localField.schema.properties,
                                 startDate: {
                                   ...localField.schema.properties.startDate,
-                                  minimum: dateValue,
+                                  formatMinimum: dateValue,
                                 },
                                 endDate: {
                                   ...localField.schema.properties.endDate,
-                                  minimum: dateValue,
+                                  formatMinimum: dateValue,
                                 },
                               },
                             };
@@ -2615,7 +2617,8 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           }}
                           inputProps={{
                             max: (() => {
-                              const maxEndDate = localField.schema?.properties?.endDate?.maximum;
+                              const maxEndDate =
+                                localField.schema?.properties?.endDate?.formatMaximum;
                               return maxEndDate ? maxEndDate.split('T')[0] : undefined;
                             })(),
                           }}
@@ -2626,7 +2629,8 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             shrink: true,
                           }}
                           InputProps={{
-                            endAdornment: localField.schema?.properties?.startDate?.minimum && (
+                            endAdornment: localField.schema?.properties?.startDate
+                              ?.formatMinimum && (
                               <InputAdornment position="end">
                                 <IconButton
                                   size="small"
@@ -2636,11 +2640,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                         ...localField.schema.properties,
                                         startDate: {
                                           ...localField.schema.properties.startDate,
-                                          minimum: undefined,
+                                          formatMinimum: undefined,
                                         },
                                         endDate: {
                                           ...localField.schema.properties.endDate,
-                                          minimum: undefined,
+                                          formatMinimum: undefined,
                                         },
                                       },
                                     })
@@ -2667,7 +2671,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           type="date"
                           fullWidth
                           value={(() => {
-                            const maxDate = localField.schema?.properties?.endDate?.maximum;
+                            const maxDate = localField.schema?.properties?.endDate?.formatMaximum;
                             return maxDate ? maxDate.split('T')[0] : '';
                           })()}
                           onChange={(e) => {
@@ -2684,11 +2688,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                 ...localField.schema.properties,
                                 startDate: {
                                   ...localField.schema.properties.startDate,
-                                  maximum: dateValue,
+                                  formatMaximum: dateValue,
                                 },
                                 endDate: {
                                   ...localField.schema.properties.endDate,
-                                  maximum: dateValue,
+                                  formatMaximum: dateValue,
                                 },
                               },
                             };
@@ -2718,7 +2722,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                           inputProps={{
                             min: (() => {
                               const minStartDate =
-                                localField.schema?.properties?.startDate?.minimum;
+                                localField.schema?.properties?.startDate?.formatMinimum;
                               return minStartDate ? minStartDate.split('T')[0] : undefined;
                             })(),
                           }}
@@ -2729,7 +2733,7 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                             shrink: true,
                           }}
                           InputProps={{
-                            endAdornment: localField.schema?.properties?.endDate?.maximum && (
+                            endAdornment: localField.schema?.properties?.endDate?.formatMaximum && (
                               <InputAdornment position="end">
                                 <IconButton
                                   size="small"
@@ -2739,11 +2743,11 @@ const FieldProperties = ({ field, onFieldUpdate, fields, setFields }) => {
                                         ...localField.schema.properties,
                                         startDate: {
                                           ...localField.schema.properties.startDate,
-                                          maximum: undefined,
+                                          formatMaximum: undefined,
                                         },
                                         endDate: {
                                           ...localField.schema.properties.endDate,
-                                          maximum: undefined,
+                                          formatMaximum: undefined,
                                         },
                                       },
                                     })

--- a/packages/react-form-builder/src/components/FormPreview.jsx
+++ b/packages/react-form-builder/src/components/FormPreview.jsx
@@ -173,7 +173,32 @@ const FormPreview = ({
   const isProgrammaticUpdateRef = useRef(false);
 
   const { t, i18n } = useTranslation();
-  const ajv = useMemo(() => createAjv({ useDefaults: false }), []);
+  const ajv = useMemo(() => {
+    const ajvInstance = createAjv({ useDefaults: false });
+    if (!ajvInstance.getKeyword('formatMinimum')) {
+      ajvInstance.addKeyword({
+        keyword: 'formatMinimum',
+        type: 'string',
+        schemaType: 'string',
+        validate: function validate(schema, data) {
+          if (!data) return true;
+          return new Date(data) >= new Date(schema);
+        },
+      });
+    }
+    if (!ajvInstance.getKeyword('formatMaximum')) {
+      ajvInstance.addKeyword({
+        keyword: 'formatMaximum',
+        type: 'string',
+        schemaType: 'string',
+        validate: function validate(schema, data) {
+          if (!data) return true;
+          return new Date(data) <= new Date(schema);
+        },
+      });
+    }
+    return ajvInstance;
+  }, []);
 
   const [key, setKey] = useState(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -236,6 +261,10 @@ const FormPreview = ({
       case 'minimum':
         return 'validation.minimum';
       case 'maximum':
+        return 'validation.maximum';
+      case 'formatMinimum':
+        return 'validation.minimum';
+      case 'formatMaximum':
         return 'validation.maximum';
       default:
         return 'validation.generic';

--- a/packages/react-form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/react-form-builder/src/controls/CustomDateControl.jsx
@@ -15,14 +15,18 @@ const CustomDateControl = (props) => {
     schema?.type === 'object' && schema?.properties?.startDate && schema?.properties?.endDate;
 
   // For single date fields
-  const minDate = schema?.minimum;
-  const maxDate = schema?.maximum;
+  const minDate = schema?.formatMinimum || schema?.minimum;
+  const maxDate = schema?.formatMaximum || schema?.maximum;
 
   // For date range fields
-  const startDateMinimum = schema?.properties?.startDate?.minimum;
-  const startDateMaximum = schema?.properties?.startDate?.maximum;
-  const endDateMinimum = schema?.properties?.endDate?.minimum;
-  const endDateMaximum = schema?.properties?.endDate?.maximum;
+  const startDateMinimum =
+    schema?.properties?.startDate?.formatMinimum || schema?.properties?.startDate?.minimum;
+  const startDateMaximum =
+    schema?.properties?.startDate?.formatMaximum || schema?.properties?.startDate?.maximum;
+  const endDateMinimum =
+    schema?.properties?.endDate?.formatMinimum || schema?.properties?.endDate?.minimum;
+  const endDateMaximum =
+    schema?.properties?.endDate?.formatMaximum || schema?.properties?.endDate?.maximum;
 
   const isReadOnly = uischema?.options?.readonly;
   const includeTime = uischema?.options?.includeTime || false;


### PR DESCRIPTION
## Summary
1. Add formatMinimum and formatMaximum keywords for validation by ajv
2. Respective changes in customSelect control

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1437" height="770" alt="Screenshot 2026-02-06 at 5 20 54 PM" src="https://github.com/user-attachments/assets/5bad1e72-bec8-4dfa-90c7-f2d5a1e70641" />
<img width="1438" height="777" alt="Screenshot 2026-02-06 at 5 21 15 PM" src="https://github.com/user-attachments/assets/2c62dbd7-84af-42b0-9b56-e1473931e386" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
3. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
4. Build library: `yarn workspace react-form-builder build`
5. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
