### PR TITLE
Correct border styles for selected and group fields in SortableFieldItem

### DIFF
--- a/packages/react-form-builder/src/components/FormStructure.jsx
+++ b/packages/react-form-builder/src/components/FormStructure.jsx
@@ -92,12 +92,12 @@ const SortableFieldItem = ({
     ml: level * 2,
     cursor: 'pointer',
     border: isSelected
-      ? `2px solid ${theme.palette.primary.main}`
-      : isGroup
-        ? `2px solid ${theme.palette.warning.main}`
+      ? isGroup
+        ? `2px solid ${theme.palette.primary.main}`
         : isArray
           ? `2px solid ${theme.palette.info.main}`
-          : `1px solid ${theme.palette.grey[200]}`,
+          : `2px solid ${theme.palette.primary.main}`
+      : `1px solid ${theme.palette.grey[200]}`,
     borderRadius: 2,
     transition: 'all 0.2s ease',
     '&:hover': {
@@ -193,7 +193,10 @@ const SortableFieldItem = ({
       <Paper
         elevation={isSelected ? 2 : 0}
         sx={(theme) => fieldPaperSx(theme, { isSelected, isGroup, isArray, level })}
-        onClick={() => onFieldSelect(field)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onFieldSelect(field);
+        }}
         onContextMenu={handleContextMenu}
       >
         <Box sx={rowBetweenSx}>


### PR DESCRIPTION
## Summary
1. Changed border styling for array , groups and layouts by conditions 
2. Stop bubbling of event for inner field by e.stopPropagation() 

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
<img width="1439" height="775" alt="Screenshot 2026-02-09 at 12 23 36 PM" src="https://github.com/user-attachments/assets/44c7fe89-d9b8-4de3-be72-4274130f24e0" />
<img width="1436" height="777" alt="Screenshot 2026-02-09 at 12 23 49 PM" src="https://github.com/user-attachments/assets/af22db8e-f0ab-4fc8-af25-3d5960ad5674" />


## How to Test
Steps to verify (monorepo):
1. `yarn install`
4. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
5. Build library: `yarn workspace react-form-builder build`
6. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
