### PR TITLE
Fixed date-range field validation and default value handling

### DIFF
--- a/packages/react-form-builder/src/controls/CustomDateControl.jsx
+++ b/packages/react-form-builder/src/controls/CustomDateControl.jsx
@@ -8,8 +8,19 @@ import { formatDate } from '../utils';
 const CustomDateControl = (props) => {
   const { t } = useTranslation();
 
-  const { data, handleChange, path, label, required, errors, uischema, schema, visible, enabled } =
-    props;
+  const {
+    data,
+    handleChange,
+    path,
+    label,
+    required,
+    errors,
+    uischema,
+    schema,
+    visible,
+    enabled,
+    config,
+  } = props;
 
   // Check if this is a date range field
   const isDateRange =
@@ -109,13 +120,27 @@ const CustomDateControl = (props) => {
 
   // Handle Date Range
   if (isDateRange) {
-    const startDate = data?.startDate || schema?.properties?.startDate?.default || '';
-    const endDate = data?.endDate || schema?.properties?.endDate?.default || '';
+    const startDate = data?.startDate ?? '';
+    const endDate = data?.endDate ?? '';
 
     const getFormattedDateText = (dateValue) => {
       if (!dateValue || isReadOnly) return null;
       return formatDate(dateValue, dateFormat);
     };
+
+    // Extract errors for startDate and endDate from both errors and customValidationErrors
+    const customErrors = config?.customValidationErrors || [];
+    const allErrors = [...(Array.isArray(errors) ? errors : []), ...customErrors];
+    const startDateErrors = allErrors.filter(
+      (err) =>
+        (err.instancePath === `/${path}` && err.params?.missingProperty === 'startDate') ||
+        err.instancePath === `/${path}/startDate`
+    );
+    const endDateErrors = allErrors.filter(
+      (err) =>
+        (err.instancePath === `/${path}` && err.params?.missingProperty === 'endDate') ||
+        err.instancePath === `/${path}/endDate`
+    );
 
     return (
       <Box>
@@ -138,16 +163,11 @@ const CustomDateControl = (props) => {
                   startDate: e.target.value,
                 });
               }}
-              error={errors && (Array.isArray(errors) ? errors.length > 0 : !!errors)}
+              error={startDateErrors && startDateErrors.length > 0}
               helperText={(() => {
-                if (!errors) return undefined;
-                if (Array.isArray(errors) && errors.length > 0) {
-                  return errors[0].message || errors[0];
-                }
-                if (typeof errors === 'string') {
-                  return errors;
-                }
-                return undefined;
+                if (!startDateErrors || startDateErrors.length === 0) return undefined;
+                const error = startDateErrors[0];
+                return t(error.message) || error.message || error;
               })()}
               variant="outlined"
               InputLabelProps={{
@@ -204,16 +224,11 @@ const CustomDateControl = (props) => {
                   endDate: e.target.value,
                 });
               }}
-              error={errors && (Array.isArray(errors) ? errors.length > 0 : !!errors)}
+              error={endDateErrors && endDateErrors.length > 0}
               helperText={(() => {
-                if (!errors) return undefined;
-                if (Array.isArray(errors) && errors.length > 0) {
-                  return errors[0].message || errors[0];
-                }
-                if (typeof errors === 'string') {
-                  return errors;
-                }
-                return undefined;
+                if (!endDateErrors || endDateErrors.length === 0) return undefined;
+                const error = endDateErrors[0];
+                return t(error.message) || error.message || error;
               })()}
               variant="outlined"
               InputLabelProps={{

--- a/packages/react-form-builder/src/lib/schema/buildSchema.js
+++ b/packages/react-form-builder/src/lib/schema/buildSchema.js
@@ -77,6 +77,15 @@ export const buildSchemaFromFields = (fieldsArray, parentKey = null) => {
         objectSchema.required = childSchema.required;
       }
 
+      // For date-range fields, if parent is required, mark startDate and endDate as required
+      if (
+        field.required &&
+        objectSchema.properties?.startDate &&
+        objectSchema.properties?.endDate
+      ) {
+        objectSchema.required = ['startDate', 'endDate'];
+      }
+
       properties[field.key] = objectSchema;
       if (field.required) {
         required.push(field.key);


### PR DESCRIPTION
1. Changed default value handling to allow clearing fields
2. Added logic to extract and filter validation errors for individual startDate/endDate fields

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots

<img width="1440" height="814" alt="Screenshot 2026-02-12 at 10 01 26 AM" src="https://github.com/user-attachments/assets/af487415-f2fd-480e-a464-e422c27a41cc" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
