### PR TITLE
Fixed issue with responsive screen

### DIFF
--- a/examples/react-form-builder-basic/src/App.jsx
+++ b/examples/react-form-builder-basic/src/App.jsx
@@ -1240,7 +1240,6 @@ const schemas = [
 ];
 
 const devicePresets = [
-  { id: 'responsive', label: 'Responsive', width: 1376, height: 570 },
   { id: 'iphone-se', label: 'iPhone SE', width: 375, height: 667 },
   { id: 'iphone-xr', label: 'iPhone XR', width: 414, height: 896 },
   { id: 'iphone-12-pro', label: 'iPhone 12 Pro', width: 390, height: 844 },
@@ -1259,6 +1258,7 @@ const devicePresets = [
   { id: 'nest-hub', label: 'Nest Hub', width: 1024, height: 600 },
   { id: 'nest-hub-max', label: 'Nest Hub Max', width: 1280, height: 800 },
   { id: 'hd-720p', label: 'HD 720p', width: 1280, height: 720 },
+  { id: 'full-hd-1080p', label: 'Full HD 1080p', width: 1920, height: 1080 },
 ];
 
 export default function App() {

--- a/packages/react-form-builder/src/components/FormBuilder.jsx
+++ b/packages/react-form-builder/src/components/FormBuilder.jsx
@@ -86,6 +86,12 @@ const FormBuilder = ({
       { id: 'hd-720p', label: 'HD 720p', width: 1280, height: 720 },
       { id: 'full-hd-1080p', label: 'Full HD 1080p', width: 1920, height: 1080 },
     ];
+  } else {
+    const newScreens = screenResolutions.filter((obj) => obj.id !== 'responsive');
+    screenResolutions = [
+      { id: 'responsive', label: 'Responsive', width: 1376, height: 570 },
+      ...newScreens,
+    ];
   }
 
   // Drag and Drop state


### PR DESCRIPTION
## Summary
Fixed issue with responsive screen now user will always have responsive option in screen as first entry and if he tries to add it multiple time those will be removed and only 1 entry will be kept. 

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.
<img width="1440" height="785" alt="Screenshot 2026-02-17 at 12 41 42 PM" src="https://github.com/user-attachments/assets/41dc972e-3b32-4b9f-a3e5-cb40d48a2cab" />

## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
