### PR TITLE
feat: add settings panel

### DIFF
--- a/packages/react-form-builder/src/components/FieldPalette.jsx
+++ b/packages/react-form-builder/src/components/FieldPalette.jsx
@@ -170,6 +170,12 @@ const FieldPalette = ({
     setIsSettingsDrawerOpen(true);
   };
 
+  // Check if there are any changes to enable/disable save button
+  const hasChanges = React.useMemo(() => {
+    if (!isSettingsDrawerOpen) return false;
+    return JSON.stringify(tempVisibleFields) !== JSON.stringify(visibleFields);
+  }, [tempVisibleFields, visibleFields, isSettingsDrawerOpen]);
+
   const handleSettingsSave = () => {
     if (onVisibleFieldsChange) {
       onVisibleFieldsChange(tempVisibleFields);
@@ -360,7 +366,7 @@ const FieldPalette = ({
           onClose={handleSettingsCancel}
           sx={{
             '& .MuiDrawer-paper': {
-              width: 320,
+              width: 400,
               boxSizing: 'border-box',
             },
           }}
@@ -522,12 +528,17 @@ const FieldPalette = ({
             </Box>
 
             {/* Action Buttons */}
-            <Box sx={{ mt: 2, display: 'flex', gap: 1, justifyContent: 'space-between' }}>
-              <Button variant="outlined" onClick={handleSettingsCancel}>
-                {t('cancel', 'Cancel')}
-              </Button>
-              <Button variant="contained" onClick={handleSettingsSave}>
+            <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
+              <Button
+                fullWidth
+                variant="contained"
+                onClick={handleSettingsSave}
+                disabled={!hasChanges}
+              >
                 {t('save', 'Save')}
+              </Button>
+              <Button fullWidth onClick={handleSettingsCancel} variant="outlined">
+                {t('cancel', 'Cancel')}
               </Button>
             </Box>
           </Box>


### PR DESCRIPTION
## Summary
add settings panel it should appear like drawer with accordions for each section with save and cancel button
## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots

<img width="1080" height="860" alt="image" src="https://github.com/user-attachments/assets/955c3bde-b048-428d-8276-c1700b6790e7" />

<img width="1080" height="860" alt="image" src="https://github.com/user-attachments/assets/bd5a5dc0-e71c-4f57-99c4-5f8c0b1e68bf" />

<img width="1080" height="860" alt="image" src="https://github.com/user-attachments/assets/bfd8196a-54b6-4824-914f-e0bcc631c462" />
## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
