### PR TITLE
Toggle set to enable by default for responsive toolbar

### DIFF
--- a/packages/react-form-builder/src/components/FormBuilder.jsx
+++ b/packages/react-form-builder/src/components/FormBuilder.jsx
@@ -65,8 +65,8 @@ const FormBuilder = ({
   const [toolbarVisibility, setToolbarVisibility] = useState({});
   const [screens, setScreens] = useState(screenResolutions);
   const [responsiveState, setResponsiveState] = useState({
-    showResplayout: false,
-    showRotateOption: false,
+    showResplayout: true,
+    showRotateOption: true,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Toggle set to enable by default for responsive toolbar

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor

## Motivation
Why is this change necessary?

## Screenshots
If UI changes, add screenshots/GIFs.
<img width="1440" height="785" alt="Screenshot 2026-02-20 at 12 26 33 PM" src="https://github.com/user-attachments/assets/ad70c3c0-1f02-45d4-8ae3-21abbeb7dab0" />


## How to Test
Steps to verify (monorepo):
1. `yarn install`
2. Run react-form-builder-basic: `yarn dev` (http://localhost:3000)
3. Build library: `yarn workspace react-form-builder build`
4. Optional tests: `yarn workspace react-form-builder test`

## Checklist
- [ ] Builds locally (`yarn build`)
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated
- [ ] Linked issues

## Notes
Any additional notes for reviewers.
